### PR TITLE
Feature/akismet comment check

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+checkout:
+  post:
+    - git submodule sync
+    - git submodule update --init
+    - git clone git@github.com:WhiskeyMedia/scout.git scout.git
+dependencies:
+  override:
+
+  cache_directories:
+    - venv/src
+    - ~/.pip/cache
+test:
+  override:
+#    - python setup.py test

--- a/ella_flatcomments/forms.py
+++ b/ella_flatcomments/forms.py
@@ -15,6 +15,7 @@ class FlatCommentForm(ModelForm):
     def __init__(self, content_object, user, *args, **kwargs):
         self.content_object = content_object
         self.user = user
+        self.request = kwargs.pop('request', None)
         super(FlatCommentForm, self).__init__(*args, **kwargs)
 
         # store the auto fields on the comment instance directly
@@ -40,5 +41,5 @@ class FlatCommentMultiForm(MultiForm):
 
     def post(self):
         comment = super(FlatCommentMultiForm, self).save(commit=False)
-        success, reason = comment.post()
+        success, reason = comment.post(request=getattr(self.model_form, 'request', None))
         return comment, success, reason

--- a/ella_flatcomments/models.py
+++ b/ella_flatcomments/models.py
@@ -20,6 +20,7 @@ from ella_flatcomments.conf import comments_settings
 
 redis = Redis(**comments_settings.REDIS)
 
+EDIT_TIMER_ENABLED = getattr(settings, 'EDIT_TIMER_ENABLED', False)
 EDIT_TIMER_MINUTES = getattr(settings, 'EDIT_TIMER_MINUTES', 15)
 
 
@@ -184,6 +185,11 @@ class FlatComment(models.Model):
         if self.submit_date is None:
             self.submit_date = timezone.now()
         super(FlatComment, self).save(**kwargs)
+
+    def has_edit_timer(self):
+        '''has_edit_timer() -> bool
+        '''
+        return EDIT_TIMER_ENABLED
 
     def is_edit_timer_expired(self):
         '''is_edit_timer_expired() -> bool

--- a/ella_flatcomments/urls.py
+++ b/ella_flatcomments/urls.py
@@ -1,6 +1,9 @@
 from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext as _
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except:
+    from django.conf.urls.defaults import patterns, url
 
 from ella_flatcomments.views import list_comments, post_comment, comment_detail, moderate_comment, lock_comments, unlock_comments
 

--- a/ella_flatcomments/views.py
+++ b/ella_flatcomments/views.py
@@ -73,6 +73,13 @@ def post_comment(request, context, comment_id=None):
         if comment.user != request.user and not comments_settings.IS_MODERATOR_FUNC(request.user):
             return HttpResponseForbidden("You cannot edit other people's comments.")
 
+        # Don't allow users to edit a comment after the allowed edit time has expired
+        if comment.user == request.user and not comments_settings.IS_MODERATOR_FUNC(request.user) and comment.is_edit_timer_expired():
+            if request.is_ajax():
+                context.update({'comment': comment})
+                return TemplateResponse(request, get_template('comment_detail_async.html', context['object']), context)
+            return HttpResponseForbidden("The allowed time to edit the comment has expired.")
+
     data, files = None, None
     if request.method == 'POST':
         data, files = request.POST, request.FILES

--- a/ella_flatcomments/views.py
+++ b/ella_flatcomments/views.py
@@ -83,8 +83,7 @@ def post_comment(request, context, comment_id=None):
     data, files = None, None
     if request.method == 'POST':
         data, files = request.POST, request.FILES
-
-    form = FlatCommentMultiForm(context['object'], user, data=data, files=files, instance=comment)
+    form = FlatCommentMultiForm(context['object'], user, data=data, files=files, instance=comment, request=request)
     if form.is_valid():
         comment, success, reason = form.post()
         if not success:


### PR DESCRIPTION
Right now, FlatComment.post supports a request parameter, but that parameter is not passed in through the creating view. 
In this branch, I've added the request as a parameter so that it can be used in comment checks or other functions run in response to comment_will_be_posted signals
